### PR TITLE
Introduce a long text question type

### DIFF
--- a/src/Entity/AnswerLongText.php
+++ b/src/Entity/AnswerLongText.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @author  Moritz Vondano
+ * @license MIT
+ */
+
+namespace Mvo\ContaoSurvey\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mvo\ContaoSurvey\Report\DataContainer;
+
+/**
+ * @ORM\Entity()
+ *
+ * @property QuestionText $question
+ */
+class AnswerLongText extends Answer
+{
+    /**
+     * @ORM\Column(name="user_value_longtext", type="text", nullable=true)
+     */
+    private ?string $text = null;
+
+    public function getText(): ?string
+    {
+        return $this->text;
+    }
+
+    public function setText(?string $text): void
+    {
+        $this->text = $text;
+    }
+
+    public function exportData(DataContainer $container): void
+    {
+        $container->setValue($this->getText());
+    }
+}

--- a/src/Entity/QuestionLongText.php
+++ b/src/Entity/QuestionLongText.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @author  Moritz Vondano
+ * @license MIT
+ */
+
+namespace Mvo\ContaoSurvey\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mvo\ContaoSurvey\Report\DataContainer;
+
+/**
+ * @ORM\Entity()
+ */
+class QuestionLongText extends Question
+{
+    protected function defineData(DataContainer $container): void
+    {
+        $container->defineValue(DataContainer::EMPTY_LABEL);
+    }
+}

--- a/src/Form/AnswerType/AnswerLongTextType.php
+++ b/src/Form/AnswerType/AnswerLongTextType.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @author  Moritz Vondano
+ * @license MIT
+ */
+
+namespace Mvo\ContaoSurvey\Form\AnswerType;
+
+use Mvo\ContaoSurvey\Entity\QuestionText;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class AnswerLongTextType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var QuestionText $question */
+        $question = $builder->getData()->getQuestion();
+
+        $fieldOptions = [
+            'required' => $question->isMandatory(),
+            'constraints' => $question->isMandatory() ? [new NotBlank()] : [],
+            'attr' => [
+                'class' => 'type--longtext',
+            ],
+            'label' => 'Free text',
+        ];
+
+        $builder->add('text', TextareaType::class, $fieldOptions);
+    }
+
+    public function getBlockPrefix(): string
+    {
+        return 'survey_answer_longtext';
+    }
+}

--- a/src/Form/AnswerType/AnswerTextType.php
+++ b/src/Form/AnswerType/AnswerTextType.php
@@ -12,7 +12,7 @@ namespace Mvo\ContaoSurvey\Form\AnswerType;
 use Mvo\ContaoSurvey\Entity\QuestionText;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\LessThanOrEqual;
@@ -62,7 +62,7 @@ class AnswerTextType extends AbstractType
             'label' => 'Free text',
         ]);
 
-        $builder->add('text', TextareaType::class, $fieldOptions);
+        $builder->add('text', TextType::class, $fieldOptions);
     }
 
     public function getBlockPrefix()

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -24,3 +24,8 @@ mvo_contao_survey:
       question: Mvo\ContaoSurvey\Entity\QuestionText
       answer: Mvo\ContaoSurvey\Entity\AnswerText
       form: Mvo\ContaoSurvey\Form\AnswerType\AnswerTextType
+
+    longtext:
+      question: Mvo\ContaoSurvey\Entity\QuestionLongText
+      answer: Mvo\ContaoSurvey\Entity\AnswerLongText
+      form: Mvo\ContaoSurvey\Form\AnswerType\AnswerLongTextType

--- a/src/Resources/contao/languages/de/survey.php
+++ b/src/Resources/contao/languages/de/survey.php
@@ -12,3 +12,4 @@ $GLOBALS['TL_LANG']['survey_question_type']['order'] = 'Reihenfolge';
 $GLOBALS['TL_LANG']['survey_question_type']['rating'] = 'Rating';
 $GLOBALS['TL_LANG']['survey_question_type']['select'] = 'Auswahl';
 $GLOBALS['TL_LANG']['survey_question_type']['text'] = 'Text';
+$GLOBALS['TL_LANG']['survey_question_type']['longtext'] = 'Langtext';

--- a/src/Resources/contao/languages/en/survey.php
+++ b/src/Resources/contao/languages/en/survey.php
@@ -12,3 +12,4 @@ $GLOBALS['TL_LANG']['survey_question_type']['order'] = 'Order';
 $GLOBALS['TL_LANG']['survey_question_type']['rating'] = 'Rating';
 $GLOBALS['TL_LANG']['survey_question_type']['select'] = 'Select';
 $GLOBALS['TL_LANG']['survey_question_type']['text'] = 'Text';
+$GLOBALS['TL_LANG']['survey_question_type']['longtext'] = 'Long text';


### PR DESCRIPTION
Another thing I like to add is the ability to differ between a long text (input type textarea) and a short text field (input type text). I like more to introduce a new question type over adding more configuration settings to the text question type. So the current text question type would render as a text input type now.