### PR TITLE
Add question type to the entity implementation

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,7 +29,6 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('types')
                     ->info('Define survey types to be registered.')
-                    ->useAttributeAsKey('name')
                     ->arrayPrototype()
                         ->children()
                             ->scalarNode('question')

--- a/src/DependencyInjection/MvoContaoSurveyExtension.php
+++ b/src/DependencyInjection/MvoContaoSurveyExtension.php
@@ -32,10 +32,10 @@ class MvoContaoSurveyExtension extends Extension
         $container->setParameter('mvo_survey.session_max_idle_time', $config['session_max_idle_time']);
 
         // register configured survey types
-        foreach ($config['types'] as $key => $item) {
+        foreach ($config['types'] as $item) {
             $container
                 ->getDefinition('mvo.survey.registry')
-                ->addMethodCall('add', [$key, $item['question'], $item['answer'], $item['form']])
+                ->addMethodCall('add', [$item['question']::getType(), $item['question'], $item['answer'], $item['form']])
             ;
         }
     }

--- a/src/Entity/Question.php
+++ b/src/Entity/Question.php
@@ -27,6 +27,8 @@ use Mvo\ContaoSurvey\Report\DataContainer;
  */
 abstract class Question extends DcaDefault
 {
+    public const TYPE = null;
+
     /**
      * @ORM\ManyToOne(targetEntity="Section", inversedBy="questions")
      * @ORM\JoinColumn(name="pid", referencedColumnName="id", onDelete="CASCADE", nullable=true)
@@ -88,6 +90,10 @@ abstract class Question extends DcaDefault
     public function __construct()
     {
         $this->answers = new ArrayCollection();
+
+        if (!\is_string(static::TYPE)) {
+            throw new \RuntimeException('Type constant has to be defined as a string');
+        }
     }
 
     public function __toString(): string
@@ -103,6 +109,11 @@ abstract class Question extends DcaDefault
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public static function getType(): string
+    {
+        return static::TYPE;
     }
 
     public function getSorting(): int

--- a/src/Entity/QuestionLongText.php
+++ b/src/Entity/QuestionLongText.php
@@ -17,6 +17,8 @@ use Mvo\ContaoSurvey\Report\DataContainer;
  */
 class QuestionLongText extends Question
 {
+    public const TYPE = 'longtext';
+
     protected function defineData(DataContainer $container): void
     {
         $container->defineValue(DataContainer::EMPTY_LABEL);

--- a/src/Entity/QuestionMatrix.php
+++ b/src/Entity/QuestionMatrix.php
@@ -18,6 +18,8 @@ use Mvo\ContaoSurvey\Report\DataContainer;
  */
 class QuestionMatrix extends Question
 {
+    public const TYPE = 'matrix';
+
     /**
      * @ORM\Column(name="matrix_columns", type="blob", length=256, nullable=true)
      *

--- a/src/Entity/QuestionOrder.php
+++ b/src/Entity/QuestionOrder.php
@@ -18,6 +18,8 @@ use Mvo\ContaoSurvey\Report\DataContainer;
  */
 class QuestionOrder extends Question
 {
+    public const TYPE = 'order';
+
     /**
      * @ORM\Column(name="options", type="blob", length=256, nullable=true)
      *

--- a/src/Entity/QuestionRating.php
+++ b/src/Entity/QuestionRating.php
@@ -17,6 +17,8 @@ use Mvo\ContaoSurvey\Report\DataContainer;
  */
 class QuestionRating extends Question
 {
+    public const TYPE = 'rating';
+
     /**
      * @ORM\Column(name="rating_range", type="integer", options={"unsigned": true})
      */

--- a/src/Entity/QuestionSelect.php
+++ b/src/Entity/QuestionSelect.php
@@ -18,6 +18,7 @@ use Mvo\ContaoSurvey\Report\DataContainer;
  */
 class QuestionSelect extends Question
 {
+    public const TYPE = 'select';
     public const USER_OPTION_VALUE = -1;
 
     /**

--- a/src/Entity/QuestionText.php
+++ b/src/Entity/QuestionText.php
@@ -17,6 +17,7 @@ use Mvo\ContaoSurvey\Report\DataContainer;
  */
 class QuestionText extends Question
 {
+    public const TYPE = 'text';
     public const VALIDATION__NONE = 0;
     public const VALIDATION__AGE = 1;
 

--- a/src/Resources/config/config.yaml
+++ b/src/Resources/config/config.yaml
@@ -2,32 +2,26 @@ mvo_contao_survey:
   session_max_idle_time: 600
 
   types:
-    matrix:
-      question: Mvo\ContaoSurvey\Entity\QuestionMatrix
+    - question: Mvo\ContaoSurvey\Entity\QuestionMatrix
       answer: Mvo\ContaoSurvey\Entity\AnswerMatrix
       form: Mvo\ContaoSurvey\Form\AnswerType\AnswerMatrixType
-    
-    order:
-      question: Mvo\ContaoSurvey\Entity\QuestionOrder
+
+    - question: Mvo\ContaoSurvey\Entity\QuestionOrder
       answer: Mvo\ContaoSurvey\Entity\AnswerOrder
       form: Mvo\ContaoSurvey\Form\AnswerType\AnswerOrderType
-      
-    rating:
-      question: Mvo\ContaoSurvey\Entity\QuestionRating
+
+    - question: Mvo\ContaoSurvey\Entity\QuestionRating
       answer: Mvo\ContaoSurvey\Entity\AnswerRating
       form: Mvo\ContaoSurvey\Form\AnswerType\AnswerRatingType
       
-    select:
-      question: Mvo\ContaoSurvey\Entity\QuestionSelect
+    - question: Mvo\ContaoSurvey\Entity\QuestionSelect
       answer: Mvo\ContaoSurvey\Entity\AnswerSelect
       form: Mvo\ContaoSurvey\Form\AnswerType\AnswerSelectType
       
-    text:
-      question: Mvo\ContaoSurvey\Entity\QuestionText
+    - question: Mvo\ContaoSurvey\Entity\QuestionText
       answer: Mvo\ContaoSurvey\Entity\AnswerText
       form: Mvo\ContaoSurvey\Form\AnswerType\AnswerTextType
 
-    longtext:
-      question: Mvo\ContaoSurvey\Entity\QuestionLongText
+    - question: Mvo\ContaoSurvey\Entity\QuestionLongText
       answer: Mvo\ContaoSurvey\Entity\AnswerLongText
       form: Mvo\ContaoSurvey\Form\AnswerType\AnswerLongTextType


### PR DESCRIPTION
This pull request add a static `Question::getType()` method. This way it's possible to access the type information from a concrete instance of an question. For example translating the question type is possible this way.