### PR TITLE
Avoid too long names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     "ausi/slug-generator": "^1.1",
     "contao/core-bundle": "^4.10",
     "doctrine/collections": "^1.5",
+    "doctrine/dbal": "^2.10",
     "doctrine/doctrine-bundle": "^1.8 || ^2.0",
     "doctrine/orm": "^2.6.3",
     "doctrine/persistence": "^2.0",

--- a/src/EventListener/DataContainer/SurveyQuestion.php
+++ b/src/EventListener/DataContainer/SurveyQuestion.php
@@ -154,18 +154,10 @@ class SurveyQuestion
     {
         $name = $this->slugGenerator->generate($question->getQuestion());
         $base = $name;
-        $baseLength = \strlen($base);
 
         // avoid collisions
         for ($suffix = 2; $this->questionRepository->isNameAlreadyUsed($name, $question); ++$suffix) {
-            // check if name would be too long
-            if ($maxlength - $baseLength < \strlen((string) $suffix) + 1) {
-                $name = substr($base, 0, $maxlength - $baseLength - 2)."-$suffix";
-
-                continue;
-            }
-
-            $name = "$base-$suffix";
+            $name = substr($base, 0, $maxlength - \strlen((string) $suffix) - 1)."-$suffix";
         }
 
         return $name;

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -214,6 +214,7 @@ services:
       - '@translator'
       - '@twig'
       - '@mvo.survey.slug_generator'
+      - '@database_connection'
 
   mvo.survey.slug_generator:
     class: Ausi\SlugGenerator\SlugGenerator

--- a/src/Resources/contao/dca/tl_survey_question.php
+++ b/src/Resources/contao/dca/tl_survey_question.php
@@ -78,7 +78,7 @@ $GLOBALS['TL_DCA']['tl_survey_question'] =
                     'nospace' => true,
                     'rgxp' => 'fieldname',
                     'maxlength' => 255,
-                    'tl_class' => 'w50',
+                    'tl_class' => 'clr long',
                 ],
             ],
             'question' => [
@@ -87,7 +87,7 @@ $GLOBALS['TL_DCA']['tl_survey_question'] =
                 'eval' => [
                     'mandatory' => true,
                     'maxlength' => 255,
-                    'tl_class' => 'w50',
+                    'tl_class' => 'clr long',
                 ],
             ],
             'description' => [

--- a/src/Resources/contao/dca/tl_survey_question.php
+++ b/src/Resources/contao/dca/tl_survey_question.php
@@ -77,7 +77,7 @@ $GLOBALS['TL_DCA']['tl_survey_question'] =
                     'doNotCopy' => true,
                     'nospace' => true,
                     'rgxp' => 'fieldname',
-                    'maxlength' => 50,
+                    'maxlength' => 255,
                     'tl_class' => 'w50',
                 ],
             ],


### PR DESCRIPTION
This fix handles the case for too long autogenerated names. The issue is caused by a too short name field (50 chars vs. 255 chars of the question field). To avoid the issue this fix does:

1. increase the length of the name field
2. check if the generated name would be longer than the database field

@m-vo Would you mind to increase the visible length of the `name` and `question` field? I would add it to the PR so.

/cc @frontendschlampe