### PR TITLE
Abstract and fix storage

### DIFF
--- a/src/EventListener/ClearSessionListener.php
+++ b/src/EventListener/ClearSessionListener.php
@@ -9,19 +9,16 @@ declare(strict_types=1);
 
 namespace Mvo\ContaoSurvey\EventListener;
 
-use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
 class ClearSessionListener
 {
     public const SESSION_LAST_USED_KEY = '_last_used';
 
-    private NamespacedAttributeBag $storage;
     private int $maxIdleTime;
 
-    public function __construct(NamespacedAttributeBag $storage, int $maxIdleTime)
+    public function __construct(int $maxIdleTime)
     {
-        $this->storage = $storage;
         $this->maxIdleTime = $maxIdleTime;
     }
 
@@ -45,10 +42,11 @@ class ClearSessionListener
             return;
         }
 
-        $lastUsed = $this->storage->get(self::SESSION_LAST_USED_KEY);
+        $session = $request->getSession();
+        $lastUsed = $session->get(self::SESSION_LAST_USED_KEY);
 
         if (null !== $lastUsed && ($lastUsed + $this->maxIdleTime < time())) {
-            $this->storage->clear();
+            $session->clear();
         }
     }
 }

--- a/src/EventListener/DataContainer/SurveyQuestion.php
+++ b/src/EventListener/DataContainer/SurveyQuestion.php
@@ -106,7 +106,8 @@ class SurveyQuestion
 
         foreach ($this->registry->getTypes() as $type) {
             $options[$type] = $this->translator->trans(
-                'survey_question_type.'.$type, [],
+                'survey_question_type.'.$type,
+                [],
                 'contao_survey'
             );
         }

--- a/src/ExpressionLanguage/Parser.php
+++ b/src/ExpressionLanguage/Parser.php
@@ -25,6 +25,9 @@ class Parser
         return $this->getFields($rootNode);
     }
 
+    /**
+     * @return array<int, string>
+     */
     private function getFields(Node $node): array
     {
         $identifiers = [];

--- a/src/Form/SurveyManagerFactory.php
+++ b/src/Form/SurveyManagerFactory.php
@@ -11,24 +11,21 @@ namespace Mvo\ContaoSurvey\Form;
 
 use Mvo\ContaoSurvey\Entity\Survey;
 use Mvo\ContaoSurvey\Registry;
+use Mvo\ContaoSurvey\Storage\StorageInterface;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class SurveyManagerFactory
 {
     private FormFactoryInterface $formFactory;
     private Registry $registry;
-    private NamespacedAttributeBag $namespacedAttributeBag;
-    private SessionInterface $session;
+    private StorageInterface $storage;
     private bool $protectEditing;
 
-    public function __construct(FormFactoryInterface $formFactory, Registry $registry, NamespacedAttributeBag $namespacedAttributeBag, SessionInterface $session, bool $protectEditing)
+    public function __construct(FormFactoryInterface $formFactory, Registry $registry, StorageInterface $storage, bool $protectEditing)
     {
         $this->formFactory = $formFactory;
         $this->registry = $registry;
-        $this->namespacedAttributeBag = $namespacedAttributeBag;
-        $this->session = $session;
+        $this->storage = $storage;
         $this->protectEditing = $protectEditing;
     }
 
@@ -38,8 +35,7 @@ class SurveyManagerFactory
             $survey,
             $this->formFactory,
             $this->registry,
-            $this->namespacedAttributeBag,
-            $this->session,
+            $this->storage,
             $this->protectEditing
         );
     }

--- a/src/Form/SurveyStep.php
+++ b/src/Form/SurveyStep.php
@@ -11,7 +11,6 @@ namespace Mvo\ContaoSurvey\Form;
 
 use Mvo\ContaoSurvey\Entity\Question;
 use Mvo\ContaoSurvey\Entity\Section;
-use RuntimeException;
 
 class SurveyStep
 {
@@ -52,7 +51,7 @@ class SurveyStep
     public function getQuestion(string $questionName): Question
     {
         if (!isset($this->questions[$questionName])) {
-            throw new RuntimeException(sprintf('Question named "%s" does not belong to the step', $questionName));
+            throw new \RuntimeException(sprintf('Question named "%s" does not belong to the step', $questionName));
         }
 
         return $this->questions[$questionName];

--- a/src/Report/DataContainer.php
+++ b/src/Report/DataContainer.php
@@ -46,7 +46,7 @@ class DataContainer
         $this->optionLabelsById = array_flip($labelOptionMap);
     }
 
-    public function setValue($value, ?int $optionId = null): void
+    public function setValue($value, int $optionId = null): void
     {
         $value = null === $value ? $value : (string) $value;
 

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -48,16 +48,15 @@ services:
       - { name: 'doctrine.event_listener', event: 'loadClassMetadata' }
 
   # form handling
-  mvo.survey.session_storage:
-    class: Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag
+
+  mvo.survey.storage.session:
+    class: Mvo\ContaoSurvey\Storage\SessionStorage
     arguments:
-      - 'mvo.survey'
-      - '/'
+      - '@request_stack'
 
   mvo.survey.listener.clear_session:
     class: Mvo\ContaoSurvey\EventListener\ClearSessionListener
     arguments:
-      - '@mvo.survey.session_storage'
       - '%mvo_survey.session_max_idle_time%'
     tags:
       - { name: 'kernel.event_listener', event: 'kernel.request', priority: -800 }
@@ -74,8 +73,7 @@ services:
     arguments:
       - '@form.factory'
       - '@mvo.survey.registry'
-      - '@mvo.survey.session_storage'
-      - '@session'
+      - '@mvo.survey.storage.session'
       - '%mvo_survey.protect_editing%'
 
   # form types

--- a/src/Storage/SessionStorage.php
+++ b/src/Storage/SessionStorage.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @author  Moritz Vondano
+ * @license MIT
+ */
+
+namespace Mvo\ContaoSurvey\Storage;
+
+use Mvo\ContaoSurvey\EventListener\ClearSessionListener;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class SessionStorage implements StorageInterface
+{
+    private const ATTRIBUTE_PREFIX = 'mvo.survey/';
+    private SessionInterface $session;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->session = $requestStack->getSession();
+    }
+
+    public function initialize(): void
+    {
+        $this->session->start();
+        $this->session->set(ClearSessionListener::SESSION_LAST_USED_KEY, time());
+    }
+
+    public function getStepIndex(int $surveyId): int
+    {
+        return $this->session->get(self::ATTRIBUTE_PREFIX.$surveyId.'/step', 0);
+    }
+
+    public function setStepIndex(int $surveyId, int $stepIndex): void
+    {
+        $this->session->set(self::ATTRIBUTE_PREFIX.$surveyId.'/step', $stepIndex);
+    }
+
+    public function getAllAnswers(int $surveyId): array
+    {
+        return $this->session->get(self::ATTRIBUTE_PREFIX.$surveyId.'/answers', []);
+    }
+
+    public function setAnswersForStep(int $surveyId, int $step, ?array $stepAnswers): void
+    {
+        $answers = $this->getAllAnswers($surveyId);
+        $answers[$step] = $stepAnswers;
+
+        $this->session->set(self::ATTRIBUTE_PREFIX.$surveyId.'/answers', $answers);
+    }
+
+    public function getHash(int $surveyId): ?string
+    {
+        return $this->session->get(self::ATTRIBUTE_PREFIX.$surveyId.'/hash');
+    }
+
+    public function setHash(int $surveyId, string $hash): void
+    {
+        $this->session->set(self::ATTRIBUTE_PREFIX.$surveyId.'/hash', $hash);
+    }
+
+    public function reset(int $surveyId): void
+    {
+        $this->session->remove(self::ATTRIBUTE_PREFIX.$surveyId);
+    }
+}

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @author  Moritz Vondano
+ * @license MIT
+ */
+
+namespace Mvo\ContaoSurvey\Storage;
+
+use Mvo\ContaoSurvey\Entity\Answer;
+
+interface StorageInterface
+{
+    public function initialize(): void;
+
+    public function getStepIndex(int $surveyId): int;
+
+    public function setStepIndex(int $surveyId, int $stepIndex): void;
+
+    /**
+     * @return array<int,array<string,Answer|null>|null>
+     */
+    public function getAllAnswers(int $surveyId): array;
+
+    /**
+     * @param array<int,Answer|null>|null $stepAnswers
+     */
+    public function setAnswersForStep(int $surveyId, int $step, ?array $stepAnswers): void;
+
+    public function getHash(int $surveyId): ?string;
+
+    public function setHash(int $surveyId, string $hash): void;
+
+    public function reset(int $surveyId): void;
+}


### PR DESCRIPTION
This abstracts the storage used by the `SurveyManager`, handles the deprecation of the `NamespacedAttributeBag` and by that fixes an incompatibility with Sf upstream versions where the custom bag isn't registered by default.

/cc @dmolineus 
The relevant commit is here: aea208e (the other being CS)