### PR TITLE
Fix rating type off by ones

### DIFF
--- a/src/Entity/AnswerRating.php
+++ b/src/Entity/AnswerRating.php
@@ -36,6 +36,7 @@ class AnswerRating extends Answer
 
     public function exportData(DataContainer $container): void
     {
-        $container->setValue($this->getRating());
+        // Use 1-based index
+        $container->setValue($this->getRating() + 1);
     }
 }

--- a/src/Form/AnswerType/AnswerRatingType.php
+++ b/src/Form/AnswerType/AnswerRatingType.php
@@ -38,6 +38,8 @@ class AnswerRatingType extends AbstractType
             'expanded' => true,
             'required' => $question->isMandatory(),
             'constraints' => $question->isMandatory() ? [new NotBlank()] : [],
+            // Disable placeholder, so we're not getting additional options
+            'placeholder' => null,
         ]);
     }
 

--- a/src/Resources/views/Form/Rating.html.twig
+++ b/src/Resources/views/Form/Rating.html.twig
@@ -3,15 +3,14 @@
 {% block form_row %}
     <div class="{% block answer_classes %}survey_answer survey_answer--rating{% endblock %}">
         {% set options = form.rating.children %}
-        {% set activeOption = form.rating.children|filter(c => c.vars.checked)|first|default(0) %}
+        {% set activeOption = options|filter(c => c.vars.checked)|first.vars.value|default(-1) %}
 
         {# Star rating, rendered as radio inputs where selecting option `n` marks options `1..n-1` as active #}
         <div class="{% block rating_wrapper_classes %}flex flex-row space-x-1{% endblock %}"
-             x-data="{value: {{ activeOption ? activeOption.vars.value : 0 }}}">
+             x-data="{value: {{ activeOption }}}">
             {% for option in options %}
-                {% set value = option.vars.value|default(0) %}
+                {% set value = option.vars.value %}
                 {% set label = option.vars.label %}
-
                 <div class="{% block input_wrapper_classes %}{% endblock %}">
                     <input class="{% block input_classes %}hidden{% endblock %}" type="radio" id="{{ option.vars.id }}" name="{{ option.vars.full_name }}"
                            value="{{ value }}" :class="{'active': value>={{ value }}}" x-model="value" @reset="value=0"


### PR DESCRIPTION
Currently there are two 'off by one' errors :see_no_evil: :

1. additional option/star due to a rendered placeholder

1. In the report: zero-based instead of one-based.